### PR TITLE
Fix typo on probability equation

### DIFF
--- a/BOOK/probability-a-measurement-of-uncertainty.html
+++ b/BOOK/probability-a-measurement-of-uncertainty.html
@@ -934,7 +934,7 @@ P(\bar L) = 1 - P(L).
 </ul>
 <p>Applying the addition property, one finds the probability of <span class="math inline">\(F \cup L\)</span> by adding the probabilities of <span class="math inline">\(F\)</span> and <span class="math inline">\(L\)</span> and subtracting the probability of the intersection event <span class="math inline">\(F \cap L\)</span> :</p>
 <p><span class="math display">\[\begin{align*}
-P(F \cup L)  &amp;= P(A) + P(L) - P(F \cap L) \\
+P(F \cup L)  &amp;= P(F) + P(L) - P(F \cap L) \\
   &amp;= 0.521 + 0.169 - 0.088 \\
   &amp;= 0.602
 \end{align*}\]</span></p>


### PR DESCRIPTION
P(F \cup L)  &amp;= P(F) + P(L) - P(F \cap L) 

Not

P(F \cup L)  &amp;= P(A) + P(L) - P(F \cap L)