### PR TITLE
Fix typo - `i` vs `j`

### DIFF
--- a/BOOK/bayesian-hierarchical-modeling.html
+++ b/BOOK/bayesian-hierarchical-modeling.html
@@ -468,7 +468,7 @@ Y_{ij} \overset{i.i.d.}{\sim} \textrm{Normal}(\mu_j, \sigma_j),
 \label{eq:introLik}
 \tag{10.1}
 \end{equation}\]</span>
-where <span class="math inline">\(j = 1, \cdots, 5\)</span> and <span class="math inline">\(j = 1, \cdots, n_j\)</span>.</p>
+where <span class="math inline">\(j = 1, \cdots, 5\)</span> and <span class="math inline">\(i = 1, \cdots, n_j\)</span>.</p>
 </div>
 <div id="separate-estimates" class="section level3 hasAnchor" number="10.1.3">
 <h3><span class="header-section-number">10.1.3</span> Separate estimates?<a href="bayesian-hierarchical-modeling.html#separate-estimates" class="anchor-section" aria-label="Anchor link to header"></a></h3>


### PR DESCRIPTION
`j` should not be listed twice. I updated it to match the description of `i` and `j` in the previous paragraph.